### PR TITLE
Rough ESLint config and minor tweaks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  "env": {
+    "browser": true,
+    "es6": true,
+    "webextensions": true
+  },
+
+  "extends": [
+    "eslint:recommended"
+  ],
+
+  "globals": {
+    "TabSplit": false,
+    "gBrowser": false
+  },
+
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+
+  "root": true,
+
+  "rules": {
+    "eqeqeq": "off", // TODO: error
+    "no-console": "off", // TODO: warn
+    "no-unused-vars": ["error", {"vars": "all", "args": "none"}]
+  }
+};

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,7 +1,12 @@
 /* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global APP_SHUTDOWN, Components, Services, XPCOMUtils */
+/* eslint no-unused-vars: ["error", {"vars": "all", "args": "none", "varsIgnorePattern": "(startup|shutdown|install|uninstall)"}] */
+
 "use strict";
 
 const { classes: Cc, interfaces: Ci, utils: Cu } = Components;

--- a/chrome/content/js/tabsplit-store.js
+++ b/chrome/content/js/tabsplit-store.js
@@ -346,7 +346,7 @@ TabSplit.store = {
     let { col, distribution, linkedPanel } = tab;
     if ((col < 0 || col > 1 ) ||
         (distribution <= 0 || distribution >= 1) ||
-        !this._utils.getTabByLinkedPanel(tab.linkedPanel)) {
+        !this._utils.getTabByLinkedPanel(linkedPanel)) {
       return false;
     }
     return true;

--- a/chrome/content/js/tabsplit-view.js
+++ b/chrome/content/js/tabsplit-view.js
@@ -1,7 +1,11 @@
 /* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* globals CustomizableUI */
+
 /**
  * @params win {Object} ChromeWindow
  */


### PR DESCRIPTION
Current ESLint output (since turning off `eqeqeq` rule mentioned in #13):

```sh
$ npx eslint .

/Users/pdehaan/dev/github/mozilla/tab-split/chrome/content/js/tabsplit-store.js
  170:52  error  'v' is not defined                            no-undef
  186:11  error  Unexpected lexical declaration in case block  no-case-declarations

/Users/pdehaan/dev/github/mozilla/tab-split/chrome/content/js/tabsplit-view.js
  309:9   error  'selectedPanel' is assigned a value but never used        no-unused-vars
  394:21  error  'selectedLinkedPanel' is assigned a value but never used  no-unused-vars
  427:29  error  'updated' is assigned a value but never used              no-unused-vars

✖ 5 problems (5 errors, 0 warnings)
```
