### PR TITLE
Fix #8 Add a readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ To test, run `npm run build`, then load Firefox Nightly, visit `about:debugging`
 
 To iteratively develop, you can run `npm run watch` and press the `reload` button in `about:debugging` after making any changes.
 
+Acceptance Criteria
+-------------------
+
+The checklist of acceptance criteria for this project is located in the [documentation](docs/acceptance.md).
+


### PR DESCRIPTION
We already had a readme, so let's just link to the other piece of
documentation we have, the acceptance criteria.