### PR TITLE
Fix #69 Replace usages of global `win` with xpcom gunk.

### DIFF
--- a/experiment/js/tabsplit-control.js
+++ b/experiment/js/tabsplit-control.js
@@ -6,6 +6,13 @@
  * @params win {Object} ChromeWindow
  */
 
+const wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+               .getService(Components.interfaces.nsIWindowMediator);
+
+function getWindow() {
+  return wm.getMostRecentWindow("navigator:browser");
+}
+
 export default {
 
   MS_MAX_IDLE_DURATION: 1000 * 60 * 10, // 10 mins
@@ -158,7 +165,7 @@ export default {
     const windowWidth = window.innerWidth;
     this.onDraggingColumnSplitter = e => {
       const mousePosX = e.clientX;
-      win.requestAnimationFrame(() => {
+      getWindow().requestAnimationFrame(() => {
         // Cannot drag the splitter and other place at the same time
         // so safe to assume the widths are unchanged here and
         // don't have to make a sync flow call to get the widths again.
@@ -195,7 +202,7 @@ export default {
         });
       });
     };
-    win.addEventListener("mousemove", this.onDraggingColumnSplitter);
+    getWindow().addEventListener("mousemove", this.onDraggingColumnSplitter);
   },
 
   _stopDraggingColumnSplitter() {
@@ -203,7 +210,7 @@ export default {
       return;
     }
     console.log("TMP> tabsplit-control - _stopDraggingColumnSplitter");
-    win.removeEventListener("mousemove", this.onDraggingColumnSplitter);
+    getWindow().removeEventListener("mousemove", this.onDraggingColumnSplitter);
     this.onDraggingColumnSplitter = null;
   },
 
@@ -450,7 +457,7 @@ export default {
   },
 
   onResize() {
-    win.requestAnimationFrame(() => {
+    getWindow().requestAnimationFrame(() => {
       console.log("TMP> tabsplit-control - onResize");
       this._store.update({
         type: "update_tabbrowser_width",

--- a/experiment/js/tabsplit-view.js
+++ b/experiment/js/tabsplit-view.js
@@ -10,9 +10,12 @@
  * @params win {Object} ChromeWindow
  */
 
-var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+const wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                .getService(Components.interfaces.nsIWindowMediator);
-var win = wm.getMostRecentWindow("navigator:browser");
+
+function getWindow() {
+  return wm.getMostRecentWindow("navigator:browser");
+}
 
 export default {
   ID_TABSPLIT_BUTTON: "tabsplit-button",
@@ -51,7 +54,7 @@ export default {
 
   async _addTabSplitButton() {
     console.log("TMP> tabsplit-view - _addTabSplitButton");
-    let buttonForThisWindow = win.document.getElementById(this.ID_TABSPLIT_BUTTON);
+    let buttonForThisWindow = getWindow().document.getElementById(this.ID_TABSPLIT_BUTTON);
     if (buttonForThisWindow) {
       return;
     }
@@ -83,7 +86,7 @@ export default {
       CustomizableUI.addWidgetToArea(this.ID_TABSPLIT_BUTTON, "nav-bar");
     });
 
-    buttonForThisWindow = win.document.getElementById(this.ID_TABSPLIT_BUTTON);
+    buttonForThisWindow = getWindow().document.getElementById(this.ID_TABSPLIT_BUTTON);
     buttonForThisWindow.addEventListener("command", async e => {
       const tab = this._utils.getTabByLinkedPanel(this._state.selectedLinkedPanel);
       // When the status is inactive and the button is clicked,
@@ -100,7 +103,7 @@ export default {
         await this._addMenuPanel();
       }
       if (this._menuPanel.state === "closed") {
-        const anchor = win.document.getAnonymousElementByAttribute(e.target, "class", "toolbarbutton-icon");
+        const anchor = getWindow().document.getAnonymousElementByAttribute(e.target, "class", "toolbarbutton-icon");
         this._menuPanel.openPopup(anchor, "bottomcenter topright", 0, 0, false, null);
       } else if (this._menuPanel.state === "open") {
         this._menuPanel.hidePopup();
@@ -122,11 +125,11 @@ export default {
       return;
     }
     await new Promise(resolve => {
-      win.document.loadOverlay("./tabsplit-menupanel-overlay.xul", resolve);
+      getWindow().document.loadOverlay("./tabsplit-menupanel-overlay.xul", resolve);
     });
     console.log("TMP> tabsplit-view - tabsplit-menupanel-overlay.xul loaded");
 
-    this._menuPanel = win.document.getElementById("tabsplit-menupanel");
+    this._menuPanel = getWindow().document.getElementById("tabsplit-menupanel");
     this._menuPanel.addEventListener("click", e => {
       this._menuPanel.hidePopup();
       if (e.target.id === "tabsplit-menupanel-unsplit-all-button") {
@@ -300,7 +303,7 @@ export default {
       appContent.appendChild(this._cSplitter);
       this._cSplitter.addEventListener("mousedown", e => {
         this._listener.onMouseDownOnSplitter(e);
-        win.addEventListener("mouseup", e => this._listener.onMouseUpOnSplitter(e), { once: true });
+        getWindow().addEventListener("mouseup", e => this._listener.onMouseUpOnSplitter(e), { once: true });
       });
     }
 
@@ -466,7 +469,7 @@ export default {
    * the chrome UI's changes affects us on UI but not on the state.
    */
   forceUpdate() {
-    win.requestAnimationFrame(() => {
+    getWindow().requestAnimationFrame(() => {
       const added = [];
       const removed = added;
       const updated = added;
@@ -483,7 +486,7 @@ export default {
       this.update(state, tabGroupsDiff);
       return;
     }
-    win.requestAnimationFrame(() => this.update(state, tabGroupsDiff));
+    getWindow().requestAnimationFrame(() => this.update(state, tabGroupsDiff));
   }
 };
 

--- a/experiment/js/tabsplit.js
+++ b/experiment/js/tabsplit.js
@@ -11,9 +11,9 @@ const store = require('./tabsplit-store').default;
 const view = require('./tabsplit-view').default;
 const control = require('./tabsplit-control').default;
 
-var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+const wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                    .getService(Components.interfaces.nsIWindowMediator);
-var win = wm.getMostRecentWindow("navigator:browser");
+
 // The structure overview:
 // C = tabsplit-control
 // V = tabsplit-view
@@ -31,6 +31,6 @@ control.init({
   view: view,
   store: store,
   utils: utils,
-  gBrowser: win.gBrowser
+  gBrowser: wm.getMostRecentWindow("navigator:browser").gBrowser
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tab-split",
   "description": "A tab-splitting extension for Firefox",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "Mozilla (https://mozilla.org/)",
   "bugs": {
     "url": "https://github.com/mozilla/tab-split/issues"

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Tab Split",
   "description": "Tab Split allows you to see two tabs side by side in the same window.",
-  "version": "0.1.8",
+  "version": "0.1.9",
 
   "applications": {
     "gecko": {


### PR DESCRIPTION
This fixes issue #69, where the split tab could not be resized.